### PR TITLE
Restore .NET 10 solution build

### DIFF
--- a/ST.Library.UI/NodeEditor/STNodeEditor.cs
+++ b/ST.Library.UI/NodeEditor/STNodeEditor.cs
@@ -692,9 +692,6 @@ namespace ST.Library.UI.NodeEditor
                     if (!string.IsNullOrEmpty(m_find.Mark)) this.OnDrawMark(m_drawing_tools);
                     break;
             }
-            return bitmap;
-        }
-
             if (this._ShowLocation) this.OnDrawNodeOutLocation(m_drawing_tools, this.Size, m_lst_node_out);
             this.OnDrawAlert();
         }
@@ -1181,7 +1178,7 @@ namespace ST.Library.UI.NodeEditor
         protected virtual void OnDrawSelectedRectangle(DrawingTools dt, RectangleF rectf) {
             if (m_canvas == null) return;
             var fill = Color.FromArgb(this._SelectedRectangleColor.A / 3, this._SelectedRectangleColor);
-            Rectangle rect = this.CanvasToControl(m_rect_select);
+            RectangleF rect = this.CanvasToControl(m_rect_select);
             using (var stroke = new SKPaint { Color = SkiaDrawingHelper.ToSKColor(this._SelectedRectangleColor), Style = SKPaintStyle.Stroke, StrokeWidth = 1, IsAntialias = true })
             using (var bg = new SKPaint { Color = SkiaDrawingHelper.ToSKColor(fill), Style = SKPaintStyle.Fill, IsAntialias = true }) {
                 m_canvas.DrawRect(rectf.Left, rectf.Top, rectf.Width, rectf.Height, stroke);

--- a/ST.Library.UI/ST.Library.UI.csproj
+++ b/ST.Library.UI/ST.Library.UI.csproj
@@ -6,6 +6,7 @@
     <Nullable>disable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>preview</LangVersion>
+    <NoWarn>$(NoWarn);WFO1000</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WinNodeEditorDemo/WinNodeEditorDemo.csproj
+++ b/WinNodeEditorDemo/WinNodeEditorDemo.csproj
@@ -5,6 +5,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);WFO1000</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/WpfNodeEdittorDemo/WpfNodeEdittorDemo.csproj
+++ b/WpfNodeEdittorDemo/WpfNodeEdittorDemo.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);WFO1000</NoWarn>
     <ImplicitUsings>disable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>True</UseWindowsForms>


### PR DESCRIPTION
## What changed

- repair the malformed RenderEditorToCanvasLegacy method left by the recent Skia merge
- keep the selection rectangle calculation in RectangleF
- align WpfNodeEdittorDemo with the net10.0-windows library target
- suppress the new WFO1000 designer serialization diagnostic for the legacy WinForms controls

## Why

The current main branch cannot restore or compile: the WPF demo targets .NET 8 while the library targets .NET 10, and STNodeEditor.cs contains merge residue that produces syntax errors. Once those are fixed, the .NET 10 WinForms analyzer reports WFO1000 as build errors for the legacy designer-facing properties.

## Validation

- dotnet build .\WinNodeEditorTest.sln -c Debug --no-restore -v:q
- result: 0 errors, 266 existing warnings

This PR intentionally restores the existing WinForms/WPF-host baseline only. The native WPF implementation will be proposed separately so it does not obscure this repair.